### PR TITLE
Fix the number of times hobbies section retrieves data in plain theme

### DIFF
--- a/plain/index.html
+++ b/plain/index.html
@@ -130,7 +130,7 @@
                 <v-col cols="12" md="10" class="text-center">
                   <h1>#Hobbies</h1>
                 </v-col>
-                <v-col v-for="(hobby, index) in works" cols="12" sm="6" md="4" class="text-center" :key="index">
+                <v-col v-for="(hobby, index) in hobbies" cols="12" sm="6" md="4" class="text-center" :key="index">
                   <v-card :href="hobby.link" hover="hover" height="100%">
                     <v-card-text>
                       <h2>{{hobby.name}}</h2>


### PR DESCRIPTION
Type- fix

Currently in plain theme, the `for` loop in `hobbies` section runs for number of items in `works` section.
Fix that by accepting this PR.