### PR TITLE
Add Commitizen Library

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no -- commitlint --edit ${1}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,13 @@ git clone https://github.com/<your-github-username>/freefolio
 cd freefolio
 ```
 
-**4.** Create a new branch:
+**4.** Install dependencies:
+
+```bash
+npm install
+```
+
+**5.** Create a new branch:
 
 ```bash
 git checkout -b YourBranchName
@@ -48,7 +54,7 @@ git checkout -b YourBranchName
 
 ⚠️ **Make sure** not to run the commands `git add .` or `git add *`. Instead, stage your changes for each file/folder
 
-**4.** Start developement:
+**6.** Start developement:
 
 All template must conform to the following criteria:
 
@@ -68,7 +74,7 @@ And most importantly:
 
 - Have fun! <3
 
-**6.** Add those changes to the branch you just created using the git add command. To let Git track files for a commit, we need to run the following in the terminal:
+**7.** Add those changes to the branch you just created using the git add command. To let Git track files for a commit, we need to run the following in the terminal:
 
 ```bash
 git add my_new_file
@@ -85,21 +91,21 @@ git add .
 git status
 ```
 
-**7.** Now commit those changes using the git commit command:
+**8.** Now commit those changes using the `commitizen` command:
 
 ```bash
-git commit -m "<your_commit_message>"
+npx cz
 ```
 
-**8.** Push your local commits to the remote repository:
+**9.** Push your local commits to the remote repository:
 
 ```bash
 git push origin YourBranchName
 ```
 
-**9.** Create a [Pull Request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)!
+**10.** Create a [Pull Request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)!
 
-**10.** **Congratulations!** You've made your first contribution to [**Freefolio**](https://github.com/OSSPhilippines/freefolio)! 🙌🏼
+**11.** **Congratulations!** You've made your first contribution to [**Freefolio**](https://github.com/OSSPhilippines/freefolio)! 🙌🏼
 
 **_:trophy: After this, the maintainers will review the PR and will merge it if it helps move the freefolio project forward. Otherwise, it will be given constructive feedback and suggestions for the changes needed to add the PR to the codebase._**
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
     <img alt="GitHub Stars" src="https://badgen.net/github/stars/OSSPhilippines/freefolio/?style=flat-square">
   <a href="https://github.com/OSSPhilippines/freefolio/network">
     <img alt="GitHub Forks" src="https://badgen.net/github/forks/OSSPhilippines/freefolio/?style=flat-square">
+  <a href="https://commitizen.github.io/cz-cli/">
+    <img alt="GitHub Forks" src="https://img.shields.io/badge/commitizen-friendly-brightgreen.svg?style=flat-square">
 </p>
 
 A collection of **100% FREE** to use portfolio website templates.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = {extends: ['@commitlint/config-conventional']}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Free Professional Portfolio Website Templates",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepare": "husky install"
   },
   "repository": {
     "type": "git",
@@ -31,7 +32,8 @@
     "@commitlint/config-conventional": "^17.4.4",
     "commitizen": "^4.3.0",
     "cz-conventional-changelog": "^3.3.0",
-    "eslint": "^8.24.0"
+    "eslint": "^8.24.0",
+    "husky": "^8.0.3"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,13 @@
   },
   "homepage": "https://github.com/jofftiquez/freefolio#readme",
   "devDependencies": {
+    "commitizen": "^4.3.0",
+    "cz-conventional-changelog": "^3.3.0",
     "eslint": "^8.24.0"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
   },
   "homepage": "https://github.com/jofftiquez/freefolio#readme",
   "devDependencies": {
+    "@commitlint/cli": "^17.5.1",
+    "@commitlint/config-conventional": "^17.4.4",
     "commitizen": "^4.3.0",
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^8.24.0"


### PR DESCRIPTION
Resolves #24 

Downloaded Packages

- [Commitizen](https://www.npmjs.com/package/commitizen)
- [Commitlint](https://github.com/conventional-changelog/commitlint)
- [Husky](https://typicode.github.io/husky/#/)

After installing the dependencies, you can start committing changes using Commitizen. Just run the command `npx cz`.

The primary purpose of having commitlint and husky is to ensure that the commit messages adhere to conventional commits. If not, the terminal should display an error that looks like the image below.

![husky error](https://user-images.githubusercontent.com/26820513/230600327-bc8f125a-12b1-41de-a1c2-bb57a9ae8d31.png)

